### PR TITLE
Update variable name resize.md

### DIFF
--- a/articles/imagesharp/resize.md
+++ b/articles/imagesharp/resize.md
@@ -22,7 +22,7 @@ using (Image image = Image.Load(inStream))
     int height = image.Height / 2;
     image.Mutate(x => x.Resize(width, height));
 
-    image.Save(outStream);
+    image.Save(outPath);
 }
 ```
 


### PR DESCRIPTION
Since the overload of Image.Save that takes one parameter requires the parameter to be a path, i think it could be more suitable to replace "outStream" with "outPath".