### PR TITLE
Add pixel format load documentation

### DIFF
--- a/articles/imagesharp/gettingstarted.md
+++ b/articles/imagesharp/gettingstarted.md
@@ -29,6 +29,7 @@ using SixLabors.ImageSharp.Processing;
 // Open the file automatically detecting the file type to decode it.
 // Our image is now in an uncompressed, file format agnostic, structure in-memory as
 // a series of pixels.
+// You can also specify the pixel format using a type parameter (e.g. Image<Rgba32> image = Image.Load<Rgba32>("foo.jpg"))
 using (Image image = Image.Load("foo.jpg")) 
 {
     // Resize the image in place and return it for chaining.


### PR DESCRIPTION
I used ImageSharp to load an image from disk and apply pixel manipulations to it, using this guide: https://docs.sixlabors.com/articles/imagesharp/pixelbuffers.html

That guide only uses a newly constructed image and the image loading documentation (https://docs.sixlabors.com/articles/imagesharp/gettingstarted.html#loading-and-saving-images) only loads into an Image without the TPixel parameter. This PR is an attempt to bridge that gap.