### PR TITLE
Azure Blob Storage Cache Docs Update

### DIFF
--- a/articles/imagesharp.web/imagecaches.md
+++ b/articles/imagesharp.web/imagecaches.md
@@ -58,7 +58,7 @@ Once installed the cache @SixLabors.ImageSharp.Web.Caching.Azure.AzureBlobStorag
     // Optionally create the cache container on startup if not already created.
     AzureBlobStorageCache.CreateIfNotExists(options, PublicAccessType.None);
 })
-.SetCache<AzureBlobStorageImageCache>()
+.SetCache<AzureBlobStorageCache>()
 ```
 
 Images are cached using a hash of the request URL as the blob name. All appropriate metadata is stored in the blob properties to correctly serve the blob with the correct response headers.


### PR DESCRIPTION
This PR updates the example code in the docs to use the correct cache class for AzureBlobStorage.

The ``` AzureBlobStorageImageCache``` class referenced here does not exist in the project. Looking at the generated docs for [Namespace SixLabors.ImageSharp.Web.Caching.Azure](https://docs.sixlabors.com/api/ImageSharp.Web.Providers.Azure/SixLabors.ImageSharp.Web.Caching.Azure.html), it appears that ``` AzureBlobStorageCache``` is the correct cache class.