### PR TITLE
Pixel buffers and Memory Management docs

### DIFF
--- a/articles/imagesharp/memorymanagement.md
+++ b/articles/imagesharp/memorymanagement.md
@@ -1,0 +1,2 @@
+# Memory Management
+

--- a/articles/imagesharp/memorymanagement.md
+++ b/articles/imagesharp/memorymanagement.md
@@ -1,2 +1,49 @@
 # Memory Management
 
+Starting with ImageSharp 2.0, the library uses large (~4MB) discontigous chunks of unmanaged memory to represent multi-megapixel images. Internally, these buffers are heavily pooled to reduce OS allocation overhead. Unlike in ImageSharp 1.0, the pools are automatically trimmed after a certain amount of allocation inactivity, releasing the buffers to the OS, making the library more suitable for applications that do imaging operations in a periodic manner.
+
+The buffer allocation and pooling behavior is implemented by @"SixLabors.ImageSharp.Memory.MemoryAllocator" which is being used through @"SixLabors.ImageSharp.Configuration"'s @"SixLabors.ImageSharp.Configuration.MemoryAllocator" property within the library, therefore it's configurable and replacable by the user.
+
+### Configuring the pool size
+
+By deault, the maximum pool size is platform-specific, defaulting to a portion of the available physical memory on 64 bit coreclr, and to a 128MB constant size on other platforms / runtimes.
+
+We highly recommend to go with these defaults, however in certain cases it might be desirable to override the pool limit. In such cases the most straightforward solution is to replace the memory allocator globally:
+
+```C#
+Configuration.Default.MemoryAllocator = MemoryAllocator.Create(new MemoryAllocatorOptions()
+{
+    MaximumPoolSizeMegabytes = 64
+});
+```
+
+### Enforcing contiguous buffers
+
+Certain interop use cases may require multi-megapixel images to be layed out contiguously in memory so a single buffer pointer can be passed to native API-s. This can be enforced by setting @"SixLabors.ImageSharp.Configuration"'s @"SixLabors.ImageSharp.Configuration.PreferContiguousImageBuffers" to `true`. Note that this will lead to significantly reduced pooling that may hurt overall processing throughput. We don't recommend to flip this option globabally. Instead, you can enable it locally for the image instances that are expected to be contigous:
+
+```C#
+Configuration customConfig = Configuration.Default.Clone();
+customConfig.PreferContiguousImageBuffers = true;
+
+using (Image<Rgba32> image = new(customConfig, 4096, 4096))
+{
+    if (!image.DangerousTryGetSinglePixelMemory(out Memory<Rgba32> memory))
+    {
+        throw new Exception(
+            "This can only happen with multi-GB images or when PreferContiguousImageBuffers is not set to true.");
+    }
+
+    using (MemoryHandle pinHandle = memory.Pin())
+    {
+        void* ptr = pinHandle.Pointer;
+
+        // You can now pass 'ptr' to native API-s.
+        // Make sure to keep 'pinHandle', and 'image' alive while native resource work with the pointer.
+        // Make sure to Dispose() them afterwards.
+    }
+}
+```
+
+### Wrapping existing buffers as `Image<TPixel>`
+
+It's also possible to do the other way around, and wrap an existing native buffer to process it as an `Image<TPixel>`. You can use one of the @"SixLabors.ImageSharp.Image.WrapMemory*" overloads for this. Note that the resulting image is not suitable for operations that would change the dimensions of the image, such an attempt will lead to an @"SixLabors.ImageSharp.Memory.InvalidMemoryOperationException".

--- a/articles/imagesharp/memorymanagement.md
+++ b/articles/imagesharp/memorymanagement.md
@@ -2,11 +2,11 @@
 
 Starting with ImageSharp 2.0, the library uses large (~4MB) discontigous chunks of unmanaged memory to represent multi-megapixel images. Internally, these buffers are heavily pooled to reduce OS allocation overhead. Unlike in ImageSharp 1.0, the pools are automatically trimmed after a certain amount of allocation inactivity, releasing the buffers to the OS, making the library more suitable for applications that do imaging operations in a periodic manner.
 
-The buffer allocation and pooling behavior is implemented by @"SixLabors.ImageSharp.Memory.MemoryAllocator" which is being used through @"SixLabors.ImageSharp.Configuration"'s @"SixLabors.ImageSharp.Configuration.MemoryAllocator" property within the library, therefore it's configurable and replacable by the user.
+The buffer allocation and pooling behavior is implemented by @"SixLabors.ImageSharp.Memory.MemoryAllocator" which is being used through @"SixLabors.ImageSharp.Configuration"'s @"SixLabors.ImageSharp.Configuration.MemoryAllocator" property within the library, therefore it's configurable and replaceable by the user.
 
 ### Configuring the pool size
 
-By deault, the maximum pool size is platform-specific, defaulting to a portion of the available physical memory on 64 bit coreclr, and to a 128MB constant size on other platforms / runtimes.
+By default, the maximum pool size is platform-specific, defaulting to a portion of the available physical memory on 64 bit coreclr, and to a 128MB constant size on other platforms / runtimes.
 
 We highly recommend to go with these defaults, however in certain cases it might be desirable to override the pool limit. In such cases the most straightforward solution is to replace the memory allocator globally:
 
@@ -19,7 +19,7 @@ Configuration.Default.MemoryAllocator = MemoryAllocator.Create(new MemoryAllocat
 
 ### Enforcing contiguous buffers
 
-Certain interop use cases may require multi-megapixel images to be layed out contiguously in memory so a single buffer pointer can be passed to native API-s. This can be enforced by setting @"SixLabors.ImageSharp.Configuration"'s @"SixLabors.ImageSharp.Configuration.PreferContiguousImageBuffers" to `true`. Note that this will lead to significantly reduced pooling that may hurt overall processing throughput. We don't recommend to flip this option globabally. Instead, you can enable it locally for the image instances that are expected to be contigous:
+Certain interop use cases may require multi-megapixel images to be layed out contiguously in memory so a single buffer pointer can be passed to native API-s. This can be enforced by setting @"SixLabors.ImageSharp.Configuration"'s @"SixLabors.ImageSharp.Configuration.PreferContiguousImageBuffers" to `true`. Note that this will lead to significantly reduced pooling that may hurt overall processing throughput. We don't recommend to flip this option globally. Instead, you can enable it locally for the image instances that are expected to be contiguous:
 
 ```C#
 Configuration customConfig = Configuration.Default.Clone();

--- a/articles/imagesharp/pixelbuffers.md
+++ b/articles/imagesharp/pixelbuffers.md
@@ -59,6 +59,29 @@ image.ProcessPixelRows(accessor =>
 });
 ```
 
+Need to process two images simultaneously? Sure!
+
+```C#
+// Extract sub-region of sourceImage, bounded by sourceArea as a new image
+private static Image<Rgba32> Extract(Image<Rgba32> sourceImage, Rectangle sourceArea)
+{
+    Image<Rgba32> targetImage = new (sourceArea.Width, sourceArea.Height);
+    int height = sourceArea.Height;
+    sourceImage.ProcessPixelRows(targetImage, (sourceAccessor, targetAccessor) =>
+    {
+        for (int i = 0; i < height; i++)
+        {
+            Span<Rgba32> sourceRow = sourceAccessor.GetRowSpan(sourceArea.Y + i);
+            Span<Rgba32> targetRow = targetAccessor.GetRowSpan(i);
+
+            sourceRow.Slice(sourceArea.X, sourceArea.Width).CopyTo(targetRow);
+        }
+    });
+
+    return targetImage;
+}
+```
+
 ### Parallel, pixel-format agnostic image manipulation
 There is a way to process image data that is even faster than using the approach mentioned before, and that also has the advantage of working on images of any underlying pixel-format, in a completely transparent way: using the @"SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(SixLabors.ImageSharp.Processing.IImageProcessingContext,SixLabors.ImageSharp.Processing.PixelRowOperation)" APIs.
 

--- a/articles/imagesharp/pixelbuffers.md
+++ b/articles/imagesharp/pixelbuffers.md
@@ -9,7 +9,7 @@ using (Image<Rgba32> image = new Image<Rgba32>(400, 400))
 }
 ```
 
-The indexer is an order of magnitude faster than the `.GetPixel(x, y)` and `.SetPixel(x, y)` methods of `System.Drawing`, but individual `[x, y]` indexing has inherent overhead compared to more sophisticated approaches demnonstrated below.
+The indexer is an order of magnitude faster than the `.GetPixel(x, y)` and `.SetPixel(x, y)` methods of `System.Drawing`, but individual `[x, y]` indexing has inherent overhead compared to more sophisticated approaches demonstrated below.
 
 ### Efficient pixel manipulation
 If you want to achieve killer speed in your pixel manipulation routines, you should utilize the per-row methods. These methods take advantage of the [`Span<T>`-based memory manipulation primitives](https://www.codemag.com/Article/1807051/Introducing-.NET-Core-2.1-Flagship-Types-Span-T-and-Memory-T) from [System.Memory](https://www.nuget.org/packages/System.Memory/), providing a fast, yet safe low-level solution to manipulate pixel data.
@@ -42,7 +42,7 @@ image.ProcessPixelRows(accessor =>
             ref Rgba32 pixel = ref pixelRow[x];
             if (pixel.A == 0)
             {
-                // overwrite the pixel referenced by 'ref Rgba32 pixel':
+                // Overwrite the pixel referenced by 'ref Rgba32 pixel':
                 pixel = transparent;
             }
         }
@@ -66,10 +66,10 @@ foreach (ref Rgba32 pixel in pixelRow)
 Need to process two images simultaneously? Sure!
 
 ```C#
-// Extract sub-region of sourceImage as a new image
+// Extract a sub-region of sourceImage as a new image
 private static Image<Rgba32> Extract(Image<Rgba32> sourceImage, Rectangle sourceArea)
 {
-    Image<Rgba32> targetImage = new (sourceArea.Width, sourceArea.Height);
+    Image<Rgba32> targetImage = new(sourceArea.Width, sourceArea.Height);
     int height = sourceArea.Height;
     sourceImage.ProcessPixelRows(targetImage, (sourceAccessor, targetAccessor) =>
     {
@@ -154,6 +154,6 @@ using (var image = Image.LoadPixelData<Rgba32>(rgbaBytes, width, height))
 
 ### OK nice, but how do I get a single pointer or span to the underlying pixel buffer?
 
-That's the neat part, youd don't. 🙂 Well ... normally.
+That's the neat part, you don't. 🙂 Well ... normally.
 
 For custom image processing code written in C#, we highly recommend to use the methods introduced above, since ImageSharp buffers are discontiguous by default. However, certain interop use-cases may require to overcome this limitation, and we support that. Please read the [Memory Management](memorymanagement.md) section for more information.

--- a/articles/imagesharp/pixelbuffers.md
+++ b/articles/imagesharp/pixelbuffers.md
@@ -83,7 +83,7 @@ private static Image<Rgba32> Extract(Image<Rgba32> sourceImage, Rectangle source
 ```
 
 ### Parallel, pixel-format agnostic image manipulation
-There is a way to process image data that is even faster than using the approach mentioned before, and that also has the advantage of working on images of any underlying pixel-format, in a completely transparent way: using the @"SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(SixLabors.ImageSharp.Processing.IImageProcessingContext,SixLabors.ImageSharp.Processing.PixelRowOperation)" APIs.
+There is a way to process image data in a floating-point format that might be faster for  multi-core client applications, and also has the advantage of working on images of any underlying pixel-format, in a completely transparent way: using the @"SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(SixLabors.ImageSharp.Processing.IImageProcessingContext,SixLabors.ImageSharp.Processing.PixelRowOperation)" APIs.
 
 This is how you can use this extension to manipulate an image:
 
@@ -102,7 +102,7 @@ image.Mutate(c => c.ProcessPixelRowsAsVector4(row =>
 
 This API receives a @"SixLabors.ImageSharp.Processing.PixelRowOperation" instance as input, and uses it to modify the pixel data of the target image. It does so by automatically executing the input operation in parallel, on multiple pixel rows at the same time, to fully leverage the power of modern multi-core CPUs. The `ProcessPixelRowsAsVector4` extension also takes care of converting the pixel data to/from the `Vector4` format, which means the same operation can be used to easily process images of any existing pixel-format, without having to implement the processing logic again for each of them.
 
-This extension offers the fastest, easiest and most flexible way to implement custom image processors in ImageSharp.
+This extension offers fast and flexible way to implement custom image processors in ImageSharp, although the processor-level parallelism might be less optimal for high-load server-side applications. To address this, the level of parallelism can be customized by changing @"SixLabors.ImageSharp.Configuration.MaxDegreeOfParallelism".
 
 ### `Span<T>` limitations
 Please be aware that **`Span<T>` has a very specific limitation**: it is a stack-only type! Read the *Is There Anything Span Can’t Do?!* section in [this article](https://www.codemag.com/Article/1807051/Introducing-.NET-Core-2.1-Flagship-Types-Span-T-and-Memory-T) for more details.

--- a/articles/toc.md
+++ b/articles/toc.md
@@ -7,6 +7,7 @@
 #### [Create an animated GIF](imagesharp/animatedgif.md)
 ### [Working with Pixel Buffers](imagesharp/pixelbuffers.md)
 ### [Configuration](imagesharp/configuration.md)
+### [Memory Management](imagesharp/memorymanagement.md)
 
 # [ImageSharp.Drawing](imagesharp.drawing/index.md)
 ## [Getting Started](imagesharp.drawing/gettingstarted.md)


### PR DESCRIPTION
(Re)introduces `memorymanagement.md` and applies many improvements on `pixelbuffers.md`. As always, a language/grammar review can be very useful.