### PR TITLE
Resolve markdown rendering issue on Image Formats page

### DIFF
--- a/articles/imagesharp/imageformats.md
+++ b/articles/imagesharp/imageformats.md
@@ -40,6 +40,7 @@ using (var image = Image.Load(inputStream, out format))
 - `image.SaveAsTga()` (shortcut for `image.Save(new TgaEncoder())`)
 - `image.SaveAsTiff()` (shortcut for `image.Save(new TiffEncoder())`)
 - `image.SaveAsWebp()` (shortcut for `image.Save(new WebpEncoder())`)
+
 ### A Deeper Overview of ImageSharp Format Management
 
 Real life image streams are usually stored / transferred in standardized formats like Jpeg, Png, Bmp, Gif etc. An image format is represented by an [`IImageFormat`](xref:SixLabors.ImageSharp.Formats.IImageFormat) implementation.


### PR DESCRIPTION
Fixes small rendering glitch:
![image](https://user-images.githubusercontent.com/83599748/172663137-e0b14003-65af-4de6-9723-f2888e0419d6.png)
