### PR TITLE
Remove misleading ImageInfo inheritance note

### DIFF
--- a/articles/imagesharp/imageformats.md
+++ b/articles/imagesharp/imageformats.md
@@ -64,7 +64,7 @@ ImageInfo imageInfo = Image.Identify(inputStream);
 Console.WriteLine($"{imageInfo.Width}x{imageInfo.Height} | BPP: {imageInfo.PixelType.BitsPerPixel}");
 ```
 
-See [`ImageInfo`](xref:SixLabors.ImageSharp.ImageInfo) for more details about the identification result. Note that [`Image<TPixel>`](xref:SixLabors.ImageSharp.Image`1) also implements `ImageInfo`.
+See [`ImageInfo`](xref:SixLabors.ImageSharp.ImageInfo) for more details about the identification result.
 
 ### Working with Encoders
 


### PR DESCRIPTION
The docs claim that `Image<TPixel>` implements `ImageInfo`, but the [source for `Image<TPixel>`](https://github.com/SixLabors/ImageSharp/blob/main/src/ImageSharp/Image%7BTPixel%7D.cs#L19) suggests otherwise.