### PR TITLE
Note that you've got to call UseImageSharp before UseStaticFiles.

### DIFF
--- a/articles/imagesharp.web/gettingstarted.md
+++ b/articles/imagesharp.web/gettingstarted.md
@@ -17,8 +17,11 @@ public void ConfigureServices(IServiceCollection services) {
 
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
 
-    // Add the image processing middleware.
+    // Add the image processing middleware. Make sure this appears BEFORE app.UseStaticFiles(),
+    // otherwise images will be served by ASP.NET's static file middleware before ImageSharp can process them.
     app.UseImageSharp();
+
+    app.UseStaticFiles();
 }
 ```
 


### PR DESCRIPTION
Looks like ImageSharp.Web only processes images if `app.UseImageSharp();` is called before `app.UseStaticFiles();`, so added a comment to the docs to make this clear.