### PR TITLE
Replace "cache" with "provider" for image provider docs

### DIFF
--- a/articles/imagesharp.web/imageproviders.md
+++ b/articles/imagesharp.web/imageproviders.md
@@ -97,7 +97,7 @@ paket add SixLabors.ImageSharp.Web.Providers.AWS --version VERSION_NUMBER
 
 ***
 
-Once installed the cache @SixLabors.ImageSharp.Web.Providers.AWS.AWSS3StorageImageProviderOptions can be configured as follows:
+Once installed the provider @SixLabors.ImageSharp.Web.Providers.AWS.AWSS3StorageImageProviderOptions can be configured as follows:
 
 ```c#  
 // Configure and register the buckets.  


### PR DESCRIPTION
Fix the mistake of using the word "cache" for describing how to setup a provider